### PR TITLE
Added context menu items for OS X

### DIFF
--- a/package/OSX/Create .gma.workflow/Contents/Info.plist
+++ b/package/OSX/Create .gma.workflow/Contents/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Create .gma</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>runWorkflowAsService</string>
+			<key>NSSendFileTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/package/OSX/Create .gma.workflow/Contents/document.wflow
+++ b/package/OSX/Create .gma.workflow/Contents/document.wflow
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AMApplicationBuild</key>
+	<string>381</string>
+	<key>AMApplicationVersion</key>
+	<string>2.4</string>
+	<key>AMDocumentVersion</key>
+	<string>2</string>
+	<key>actions</key>
+	<array>
+		<dict>
+			<key>action</key>
+			<dict>
+				<key>AMAccepts</key>
+				<dict>
+					<key>Container</key>
+					<string>List</string>
+					<key>Optional</key>
+					<true/>
+					<key>Types</key>
+					<array>
+						<string>com.apple.applescript.object</string>
+					</array>
+				</dict>
+				<key>AMActionVersion</key>
+				<string>1.0.2</string>
+				<key>AMApplication</key>
+				<array>
+					<string>Automator</string>
+				</array>
+				<key>AMParameterProperties</key>
+				<dict>
+					<key>source</key>
+					<dict/>
+				</dict>
+				<key>AMProvides</key>
+				<dict>
+					<key>Container</key>
+					<string>List</string>
+					<key>Types</key>
+					<array>
+						<string>com.apple.applescript.object</string>
+					</array>
+				</dict>
+				<key>ActionBundlePath</key>
+				<string>/System/Library/Automator/Run AppleScript.action</string>
+				<key>ActionName</key>
+				<string>Run AppleScript</string>
+				<key>ActionParameters</key>
+				<dict>
+					<key>source</key>
+					<string>on run {input, parameters}	set title to "Create .gma"	set cmd to "clear;"	repeat with f in input		set f to f as string		set addondir to quoted form of POSIX path of f				tell application "Finder" to set fname to name of alias f as string		set isjson to fname is equal to "addon.json"		-- A "just-in-case" check. This should already be filtered by NSSendFileTypes.		if (kind of (info for alias f) is "folder") or isjson then			if isjson then				set outname to "addon"			else				set outname to fname			end if			tell application "Finder"				set out to quoted form of POSIX path of ((container of alias f as alias as string) &amp; outname &amp; ".gma")			end tell			set cmd to cmd &amp; "echo Creating " &amp; out &amp; " from " &amp; addondir &amp; ";gmosh -ic --dir " &amp; addondir &amp; " " &amp; out &amp; ";echo;"		else			if button returned of (display dialog addondir &amp; " is not a folder or a addon.json file." buttons {"Abort", "Continue"} default button 2 cancel button 1 with title title with icon caution) is "Abort" then return input		end if	end repeat	-- We store all commands into a list so we can execute them all in one Terminal window	set cmd to cmd &amp; "exit"	tell application "Terminal" to do script cmd	return inputend run</string>
+				</dict>
+				<key>BundleIdentifier</key>
+				<string>com.apple.Automator.RunScript</string>
+				<key>CFBundleVersion</key>
+				<string>1.0.2</string>
+				<key>CanShowSelectedItemsWhenRun</key>
+				<false/>
+				<key>CanShowWhenRun</key>
+				<true/>
+				<key>Category</key>
+				<array>
+					<string>AMCategoryUtilities</string>
+				</array>
+				<key>Class Name</key>
+				<string>RunScriptAction</string>
+				<key>InputUUID</key>
+				<string>D5441E70-48F7-4F9E-A121-B45BE154626C</string>
+				<key>Keywords</key>
+				<array>
+					<string>Run</string>
+				</array>
+				<key>OutputUUID</key>
+				<string>EF9A547D-F18B-4C76-B2AA-6296CB2E37DD</string>
+				<key>UUID</key>
+				<string>DFE8FCB0-2C7C-41DD-B931-7AE91D247341</string>
+				<key>UnlocalizedApplications</key>
+				<array>
+					<string>Automator</string>
+				</array>
+				<key>arguments</key>
+				<dict>
+					<key>0</key>
+					<dict>
+						<key>default value</key>
+						<string>on run {input, parameters}
+	
+	(* Your script goes here *)
+	
+	return input
+end run</string>
+						<key>name</key>
+						<string>source</string>
+						<key>required</key>
+						<string>0</string>
+						<key>type</key>
+						<string>0</string>
+						<key>uuid</key>
+						<string>0</string>
+					</dict>
+				</dict>
+				<key>isViewVisible</key>
+				<true/>
+				<key>location</key>
+				<string>309.500000:554.000000</string>
+				<key>nibPath</key>
+				<string>/System/Library/Automator/Run AppleScript.action/Contents/Resources/English.lproj/main.nib</string>
+			</dict>
+			<key>isViewVisible</key>
+			<true/>
+		</dict>
+	</array>
+	<key>connectors</key>
+	<dict/>
+	<key>workflowMetaData</key>
+	<dict>
+		<key>serviceApplicationBundleID</key>
+		<string></string>
+		<key>serviceApplicationPath</key>
+		<string></string>
+		<key>serviceInputTypeIdentifier</key>
+		<string>com.apple.Automator.fileSystemObject</string>
+		<key>serviceOutputTypeIdentifier</key>
+		<string>com.apple.Automator.nothing</string>
+		<key>serviceProcessesInput</key>
+		<integer>0</integer>
+		<key>workflowTypeIdentifier</key>
+		<string>com.apple.Automator.servicesMenu</string>
+	</dict>
+</dict>
+</plist>

--- a/package/OSX/Extract .gma.workflow/Contents/Info.plist
+++ b/package/OSX/Extract .gma.workflow/Contents/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Extract .gma</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>runWorkflowAsService</string>
+			<key>NSSendFileTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/package/OSX/Extract .gma.workflow/Contents/document.wflow
+++ b/package/OSX/Extract .gma.workflow/Contents/document.wflow
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AMApplicationBuild</key>
+	<string>381</string>
+	<key>AMApplicationVersion</key>
+	<string>2.4</string>
+	<key>AMDocumentVersion</key>
+	<string>2</string>
+	<key>actions</key>
+	<array>
+		<dict>
+			<key>action</key>
+			<dict>
+				<key>AMAccepts</key>
+				<dict>
+					<key>Container</key>
+					<string>List</string>
+					<key>Optional</key>
+					<true/>
+					<key>Types</key>
+					<array>
+						<string>com.apple.applescript.object</string>
+					</array>
+				</dict>
+				<key>AMActionVersion</key>
+				<string>1.0.2</string>
+				<key>AMApplication</key>
+				<array>
+					<string>Automator</string>
+				</array>
+				<key>AMParameterProperties</key>
+				<dict>
+					<key>source</key>
+					<dict/>
+				</dict>
+				<key>AMProvides</key>
+				<dict>
+					<key>Container</key>
+					<string>List</string>
+					<key>Types</key>
+					<array>
+						<string>com.apple.applescript.object</string>
+					</array>
+				</dict>
+				<key>ActionBundlePath</key>
+				<string>/System/Library/Automator/Run AppleScript.action</string>
+				<key>ActionName</key>
+				<string>Run AppleScript</string>
+				<key>ActionParameters</key>
+				<dict>
+					<key>source</key>
+					<string>on run {input, parameters}	set title to "Extract .gma"	set cmd to "clear;"	repeat with f in input		set f to f as string		set gma to quoted form of POSIX path of f				set len to count of f		set dotidx to len - (offset of "." in (reverse of characters of f as string)) + 1		-- A "just-in-case" check. This should already be filtered by NSSendFileTypes.		if (dotidx &lt; len) and ((strings dotidx thru len in f) is equal to ".gma") then			tell application "Finder"				set out to container of alias f as alias as string				set fname to name of alias f as string			end tell			set out to quoted form of POSIX path of (out &amp; (strings 1 thru ((offset of "." in fname) - 1) of fname) &amp; ":")			set cmd to cmd &amp; "echo Extracting " &amp; gma &amp; " to " &amp; out &amp; ";gmosh -i --extract " &amp; gma &amp; " " &amp; out &amp; ";echo;"		else			if button returned of (display dialog gma &amp; " is not a .gma file." buttons {"Abort", "Continue"} default button 2 cancel button 1 with title title with icon caution) is "Abort" then return input		end if	end repeat	-- We store all commands into a list so we can execute them all in one Terminal window	set cmd to cmd &amp; "exit"	tell application "Terminal" to do script cmd	return inputend run</string>
+				</dict>
+				<key>BundleIdentifier</key>
+				<string>com.apple.Automator.RunScript</string>
+				<key>CFBundleVersion</key>
+				<string>1.0.2</string>
+				<key>CanShowSelectedItemsWhenRun</key>
+				<false/>
+				<key>CanShowWhenRun</key>
+				<true/>
+				<key>Category</key>
+				<array>
+					<string>AMCategoryUtilities</string>
+				</array>
+				<key>Class Name</key>
+				<string>RunScriptAction</string>
+				<key>InputUUID</key>
+				<string>D5441E70-48F7-4F9E-A121-B45BE154626C</string>
+				<key>Keywords</key>
+				<array>
+					<string>Run</string>
+				</array>
+				<key>OutputUUID</key>
+				<string>EF9A547D-F18B-4C76-B2AA-6296CB2E37DD</string>
+				<key>UUID</key>
+				<string>DFE8FCB0-2C7C-41DD-B931-7AE91D247341</string>
+				<key>UnlocalizedApplications</key>
+				<array>
+					<string>Automator</string>
+				</array>
+				<key>arguments</key>
+				<dict>
+					<key>0</key>
+					<dict>
+						<key>default value</key>
+						<string>on run {input, parameters}
+	
+	(* Your script goes here *)
+	
+	return input
+end run</string>
+						<key>name</key>
+						<string>source</string>
+						<key>required</key>
+						<string>0</string>
+						<key>type</key>
+						<string>0</string>
+						<key>uuid</key>
+						<string>0</string>
+					</dict>
+				</dict>
+				<key>isViewVisible</key>
+				<true/>
+				<key>location</key>
+				<string>309.500000:567.000000</string>
+				<key>nibPath</key>
+				<string>/System/Library/Automator/Run AppleScript.action/Contents/Resources/English.lproj/main.nib</string>
+			</dict>
+			<key>isViewVisible</key>
+			<true/>
+		</dict>
+	</array>
+	<key>connectors</key>
+	<dict/>
+	<key>workflowMetaData</key>
+	<dict>
+		<key>serviceApplicationBundleID</key>
+		<string></string>
+		<key>serviceApplicationPath</key>
+		<string></string>
+		<key>serviceInputTypeIdentifier</key>
+		<string>com.apple.Automator.fileSystemObject</string>
+		<key>serviceOutputTypeIdentifier</key>
+		<string>com.apple.Automator.nothing</string>
+		<key>serviceProcessesInput</key>
+		<integer>0</integer>
+		<key>workflowTypeIdentifier</key>
+		<string>com.apple.Automator.servicesMenu</string>
+	</dict>
+</dict>
+</plist>

--- a/package/OSX/Upload to Workshop.workflow/Contents/Info.plist
+++ b/package/OSX/Upload to Workshop.workflow/Contents/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Upload to Workshop</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>runWorkflowAsService</string>
+			<key>NSSendFileTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/package/OSX/Upload to Workshop.workflow/Contents/document.wflow
+++ b/package/OSX/Upload to Workshop.workflow/Contents/document.wflow
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AMApplicationBuild</key>
+	<string>381</string>
+	<key>AMApplicationVersion</key>
+	<string>2.4</string>
+	<key>AMDocumentVersion</key>
+	<string>2</string>
+	<key>actions</key>
+	<array>
+		<dict>
+			<key>action</key>
+			<dict>
+				<key>AMAccepts</key>
+				<dict>
+					<key>Container</key>
+					<string>List</string>
+					<key>Optional</key>
+					<true/>
+					<key>Types</key>
+					<array>
+						<string>com.apple.applescript.object</string>
+					</array>
+				</dict>
+				<key>AMActionVersion</key>
+				<string>1.0.2</string>
+				<key>AMApplication</key>
+				<array>
+					<string>Automator</string>
+				</array>
+				<key>AMParameterProperties</key>
+				<dict>
+					<key>source</key>
+					<dict/>
+				</dict>
+				<key>AMProvides</key>
+				<dict>
+					<key>Container</key>
+					<string>List</string>
+					<key>Types</key>
+					<array>
+						<string>com.apple.applescript.object</string>
+					</array>
+				</dict>
+				<key>ActionBundlePath</key>
+				<string>/System/Library/Automator/Run AppleScript.action</string>
+				<key>ActionName</key>
+				<string>Run AppleScript</string>
+				<key>ActionParameters</key>
+				<dict>
+					<key>source</key>
+					<string>on run {input, parameters}	set title to "Upload to Workshop"	set cmd to "clear;"	repeat with f in input		set f to f as string		set addondir to quoted form of POSIX path of f				tell application "Finder" to set fname to name of alias f as string		-- A "just-in-case" check. This should already be filtered by NSSendFileTypes.		if (kind of (info for alias f) is "folder") or (fname is equal to "addon.json") then			set cmd to cmd &amp; "echo Uploading " &amp; addondir &amp; " to Workshop...;gmosh -i --dir " &amp; addondir &amp; ";echo;"		else			if button returned of (display dialog addondir &amp; " is not a folder or a addon.json file." buttons {"Abort", "Continue"} default button 2 cancel button 1 with title title with icon caution) is "Abort" then return input		end if	end repeat	-- We store all commands into a list so we can execute them all in one Terminal window	set cmd to cmd &amp; "exit"	tell application "Terminal" to do script cmd	return inputend run</string>
+				</dict>
+				<key>BundleIdentifier</key>
+				<string>com.apple.Automator.RunScript</string>
+				<key>CFBundleVersion</key>
+				<string>1.0.2</string>
+				<key>CanShowSelectedItemsWhenRun</key>
+				<false/>
+				<key>CanShowWhenRun</key>
+				<true/>
+				<key>Category</key>
+				<array>
+					<string>AMCategoryUtilities</string>
+				</array>
+				<key>Class Name</key>
+				<string>RunScriptAction</string>
+				<key>InputUUID</key>
+				<string>D5441E70-48F7-4F9E-A121-B45BE154626C</string>
+				<key>Keywords</key>
+				<array>
+					<string>Run</string>
+				</array>
+				<key>OutputUUID</key>
+				<string>EF9A547D-F18B-4C76-B2AA-6296CB2E37DD</string>
+				<key>UUID</key>
+				<string>DFE8FCB0-2C7C-41DD-B931-7AE91D247341</string>
+				<key>UnlocalizedApplications</key>
+				<array>
+					<string>Automator</string>
+				</array>
+				<key>arguments</key>
+				<dict>
+					<key>0</key>
+					<dict>
+						<key>default value</key>
+						<string>on run {input, parameters}
+	
+	(* Your script goes here *)
+	
+	return input
+end run</string>
+						<key>name</key>
+						<string>source</string>
+						<key>required</key>
+						<string>0</string>
+						<key>type</key>
+						<string>0</string>
+						<key>uuid</key>
+						<string>0</string>
+					</dict>
+				</dict>
+				<key>isViewVisible</key>
+				<true/>
+				<key>location</key>
+				<string>309.500000:554.000000</string>
+				<key>nibPath</key>
+				<string>/System/Library/Automator/Run AppleScript.action/Contents/Resources/English.lproj/main.nib</string>
+			</dict>
+			<key>isViewVisible</key>
+			<true/>
+		</dict>
+	</array>
+	<key>connectors</key>
+	<dict/>
+	<key>workflowMetaData</key>
+	<dict>
+		<key>serviceApplicationBundleID</key>
+		<string></string>
+		<key>serviceApplicationPath</key>
+		<string></string>
+		<key>serviceInputTypeIdentifier</key>
+		<string>com.apple.Automator.fileSystemObject</string>
+		<key>serviceOutputTypeIdentifier</key>
+		<string>com.apple.Automator.nothing</string>
+		<key>serviceProcessesInput</key>
+		<integer>0</integer>
+		<key>workflowTypeIdentifier</key>
+		<string>com.apple.Automator.servicesMenu</string>
+	</dict>
+</dict>
+</plist>

--- a/package/OSX/install.command
+++ b/package/OSX/install.command
@@ -17,6 +17,13 @@ cp required/steam_appid.txt /opt/gmosh/steam_appid.txt >> install.log  2>> insta
 chmod +x /opt/gmosh/gmpublish_osx >> install.log 2>> install.log
 chmod +x /opt/gmosh/gmosh >> install.log 2>> install.log
 
+cp -r *.workflow /Library/Services/ >> install.log 2>> install.log
+/usr/libexec/PlistBuddy -c "Set :NSServices:0:NSSendFileTypes:0 dyn.ah62d4rv4ge80s5pb" /Library/Services/Extract\ .gma.workflow/Contents/Info.plist >> install.log 2>> install.log
+/usr/libexec/PlistBuddy -c "Set :NSServices:0:NSSendFileTypes:0 public.folder" /Library/Services/Create\ .gma.workflow/Contents/Info.plist >> install.log 2>> install.log
+/usr/libexec/PlistBuddy -c "Add :NSServices:0:NSSendFileTypes: string 'public.json'" /Library/Services/Create\ .gma.workflow/Contents/Info.plist >> install.log 2>> install.log
+/usr/libexec/PlistBuddy -c "Set :NSServices:0:NSSendFileTypes:0 public.folder" /Library/Services/Upload\ to\ Workshop.workflow/Contents/Info.plist >> install.log 2>> install.log
+/usr/libexec/PlistBuddy -c "Add :NSServices:0:NSSendFileTypes: string 'public.json'" /Library/Services/Upload\ to\ Workshop.workflow/Contents/Info.plist >> install.log 2>> install.log
+
 echo "" >> install.log
 echo "Installation completed" >> install.log
 

--- a/package/OSX/uninstall.command
+++ b/package/OSX/uninstall.command
@@ -8,6 +8,10 @@ if [ -L /usr/bin/gmosh ]; then rm /usr/bin/gmosh >> uninstall.log 2>> uninstall.
 if [ -d /opt/gmosh ]; then rm -r /opt/gmosh >> uninstall.log 2>> uninstall.log; fi
 if [ -L /usr/lib/libsteam_api.dylib ]; then rm /usr/lib/libsteam_api.dylib >> uninstall.log 2>> uninstall.log; fi
 if [ -L /usr/bin/gmpublish_osx ]; then rm /usr/bin/gmpublish_osx >> uninstall.log 2>> uninstall.log; fi
+# .workflow files are packages, which are directories
+if [ -d /Library/Services/Extract\ .gma.workflow ]; then rm -r /Library/Services/Extract\ .gma.workflow; fi
+if [ -d /Library/Services/Create\ .gma.workflow ]; then rm -r /Library/Services/Create\ .gma.workflow; fi
+if [ -d /Library/Services/Upload\ to\ Workshop.workflow ]; then rm -r /Library/Services/Upload\ to\ Workshop.workflow; fi
 
 echo "" >> uninstall.log
 echo "Uninstallation completed" >> uninstall.log


### PR DESCRIPTION
The .workflows show up as directories in Git as they technically are but double-clicking them in OS X will open them in Automator (comes with OS X) where you can edit the script.

It's done in AppleScript because it works well with automating tasks. Basically the only thing it's used for nowadays.

The pictures are just something Automator adds on save so that when you press space on the file in Finder, you can quickly see the contents of the file. Though there seems to be a bug where the script contents are rendered upside down in the screenshot. Doesn't really matter as you can just open it anyway.

The install script makes it only appear for .gma files, JSON files and/or folders (depending on which item) but the AppleScripts themselves have "just-in-case" checks.

The items appear at the bottom of the context menu. If the user has 5 or more context menu items installed then his will be moved under a single 'Services' item which will reveal all the items when you hover over it. This is just something OS X does to keep the menu clean.
